### PR TITLE
Upgrade tmodloader to 0.11.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,36 +1,40 @@
-# METADATA
-FROM debian:testing-slim
-LABEL maintainer="joe.stratton@asu.edu"
+FROM frolvlad/alpine-glibc:alpine-3.10 as build
 
 ARG TMOD_VERSION=0.11.5
 ARG TERRARIA_VERSION=1353
 
-# system update
-RUN apt-get -y update &&\
-    apt-get -y install wget unzip &&\
-    apt-get -y clean
+RUN apk update &&\
+    apk add --no-cache --virtual build curl unzip
 
 WORKDIR /terraria-server
 
-# get vanilla server
-RUN wget "http://terraria.org/server/terraria-server-${TERRARIA_VERSION}.zip" &&\
+RUN curl -SLO "http://terraria.org/server/terraria-server-${TERRARIA_VERSION}.zip" &&\
     unzip terraria-server-*.zip &&\
     rm terraria-server-*.zip &&\
     cp --verbose -a "${TERRARIA_VERSION}/Linux/." . &&\
-    rm -rf "${TERRARIA_VERSION}"
+    rm -rf "${TERRARIA_VERSION}" &&\
+    rm TerrariaServer.bin.x86 TerrariaServer.exe
 
-# add in tModLoader
-RUN  wget -qO - "https://github.com/tModLoader/tModLoader/releases/download/v${TMOD_VERSION}/tModLoader.Linux.v${TMOD_VERSION}.tar.gz" | tar -xvz &&\
-    chmod u+x tModLoaderServer* Terraria TerrariaServer.*
+RUN curl -SL "https://github.com/tModLoader/tModLoader/releases/download/v${TMOD_VERSION}/tModLoader.Linux.v${TMOD_VERSION}.tar.gz" | tar -xvz &&\
+    chmod u+x tModLoaderServer* Terraria TerrariaServer.* &&\
+    mv TerrariaServer.bin.x86_64 tModLoaderServer.bin.x86_64 &&\
+    rm *.txt *.jar
 
-# access data directory
+FROM frolvlad/alpine-glibc:alpine-3.10
+
+WORKDIR /terraria-server
+COPY --from=build /terraria-server ./
+
+RUN apk update &&\
+    apk add --no-cache procps tmux
 RUN ln -s ${HOME}/.local/share/Terraria/ /terraria
+COPY inject.sh /usr/local/bin/inject
 
-# Add default config file
-COPY config.txt .
-
-# ports used
 EXPOSE 7777
+ENV TMOD_SHUTDOWN_MSG="Shutting down!"
+ENV TMOD_AUTOSAVE_INTERVAL="*/10 * * * *"
 
-# start server
-ENTRYPOINT [ "/terraria-server/tModLoaderServer", "-config", "config.txt" ]
+COPY config.txt entrypoint.sh ./
+RUN chmod +x entrypoint.sh /usr/local/bin/inject
+
+ENTRYPOINT [ "/terraria-server/entrypoint.sh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,8 +26,11 @@ RUN  wget -qO - "https://github.com/tModLoader/tModLoader/releases/download/v${T
 # access data directory
 RUN ln -s ${HOME}/.local/share/Terraria/ /terraria
 
+# Add default config file
+COPY config.txt .
+
 # ports used
 EXPOSE 7777
 
 # start server
-CMD [ "/terraria-server/tModLoaderServer" ]
+ENTRYPOINT [ "/terraria-server/tModLoaderServer", "-config", "config.txt" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM frolvlad/alpine-glibc:alpine-3.10 as build
 
-ARG TMOD_VERSION=0.11.5
+ARG TMOD_VERSION=0.11.6.1
 ARG TERRARIA_VERSION=1353
 
 RUN apk update &&\

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,12 +29,15 @@ RUN apk update &&\
     apk add --no-cache procps tmux
 RUN ln -s ${HOME}/.local/share/Terraria/ /terraria
 COPY inject.sh /usr/local/bin/inject
+COPY handle-idle.sh /usr/local/bin/handle-idle
 
 EXPOSE 7777
 ENV TMOD_SHUTDOWN_MSG="Shutting down!"
 ENV TMOD_AUTOSAVE_INTERVAL="*/10 * * * *"
+ENV TMOD_IDLE_CHECK_INTERVAL=""
+ENV TMOD_IDLE_CHECK_OFFSET=0
 
 COPY config.txt entrypoint.sh ./
-RUN chmod +x entrypoint.sh /usr/local/bin/inject
+RUN chmod +x entrypoint.sh /usr/local/bin/inject /usr/local/bin/handle-idle
 
 ENTRYPOINT [ "/terraria-server/entrypoint.sh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM frolvlad/alpine-glibc:alpine-3.10 as build
 
-ARG TMOD_VERSION=0.11.6.2
+ARG TMOD_VERSION=0.11.5
 ARG TERRARIA_VERSION=1353
 
 RUN apk update &&\

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM frolvlad/alpine-glibc:alpine-3.10 as build
 
-ARG TMOD_VERSION=0.11.6.1
+ARG TMOD_VERSION=0.11.6.2
 ARG TERRARIA_VERSION=1353
 
 RUN apk update &&\

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,42 +1,33 @@
 # METADATA
 FROM debian:testing-slim
 LABEL maintainer="joe.stratton@asu.edu"
-#new
-RUN \
-        # system update \
-        apt-get -y update &&\
-        apt-get -y install wget unzip &&\
-        apt-get -y clean &&\
-        \
-        # prepare directory \
-        mkdir /terraria-server &&\
-        cd /terraria-server &&\
-        \
-        # get vanilla server test \
-        wget http://terraria.org/server/terraria-server-1353.zip &&\
-        unzip terraria-server-*.zip &&\
-        rm terraria-server-*.zip &&\
-        cp --verbose -a 1353/. . &&\
-        rm -rf 1353 &&\
-        \
-        # add in tModLoader \
-        cd Linux &&\
-        wget https://github.com/tModLoader/tModLoader/releases/download/v0.11.3/tModLoader.Linux.v0.11.3.zip &&\
-        unzip tModLoader.Linux.v*.zip &&\
-        rm tModLoader.Linux.v*.zip &&\
-        chmod u+x tModLoaderServer* &&\
-        chmod u+x Terraria &&\
-        \
-        # access data directory \
-        ln -s ${HOME}/.local/share/Terraria/ /terraria &&\
-        # remove Leftovers \
-        cd .. &&\
-        rm -rf Windows Mac
 
-RUN sed -i '0,/all/s//all\n\n\nchmod +x $KICKSTART\n\n/' /terraria-server/Linux/tModLoaderServer
+ARG TMOD_VERSION=0.11.5
+ARG TERRARIA_VERSION=1353
+
+# system update
+RUN apt-get -y update &&\
+    apt-get -y install wget unzip &&\
+    apt-get -y clean
+
+WORKDIR /terraria-server
+
+# get vanilla server
+RUN wget "http://terraria.org/server/terraria-server-${TERRARIA_VERSION}.zip" &&\
+    unzip terraria-server-*.zip &&\
+    rm terraria-server-*.zip &&\
+    cp --verbose -a "${TERRARIA_VERSION}/Linux/." . &&\
+    rm -rf "${TERRARIA_VERSION}"
+
+# add in tModLoader
+RUN  wget -qO - "https://github.com/tModLoader/tModLoader/releases/download/v${TMOD_VERSION}/tModLoader.Linux.v${TMOD_VERSION}.tar.gz" | tar -xvz &&\
+    chmod u+x tModLoaderServer* Terraria TerrariaServer.*
+
+# access data directory
+RUN ln -s ${HOME}/.local/share/Terraria/ /terraria
 
 # ports used
 EXPOSE 7777
 
 # start server
-CMD [ "/terraria-server/Linux/tModLoaderServer" ]
+CMD [ "/terraria-server/tModLoaderServer" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,12 @@ ARG TMOD_VERSION=0.11.6.2
 ARG TERRARIA_VERSION=1353
 
 RUN apk update &&\
-    apk add --no-cache --virtual build curl unzip
+    apk add --no-cache --virtual build curl unzip &&\
+    apk add --no-cache -X http://dl-cdn.alpinelinux.org/alpine/edge/testing mono
 
 WORKDIR /terraria-server
+
+RUN cp /usr/lib/libMonoPosixHelper.so .
 
 RUN curl -SLO "http://terraria.org/server/terraria-server-${TERRARIA_VERSION}.zip" &&\
     unzip terraria-server-*.zip &&\

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # tmodloader-docker
 
-Terraria server 1.3.5.3 with tModLoader v0.11.1
+Terraria server 1.3.5.3 with tModLoader v0.11.5
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,15 @@ TMOD_SHUTDOWN_MSG        | Shutting Down! | Message that appears when server is 
 TMOD_AUTOSAVE_INTERVAL   | */10 * * * *   | Cron expression that specifies how often to save the world. Default is every 10 minutes.
 TMOD_IDLE_CHECK_INTERVAL | Disabled       | Cron expression that specifies how often to check if no players are online. If none are online, the server will save the world and exit. This can be useful if your server costs are based on CPU usage.
 TMOD_IDLE_CHECK_OFFSET   | 0              | This allows for sub-second resolution if the idle check interval is specified
-    docker run -d --name tmod -e TMOD_SHUTDOWN_MSG="Goodbye" -e TMOD_AUTOSAVE_INTERVAL="*/15 * * * *" -e TMOD_IDLE_CHECK_INTERVAL="*/1 * * * *" -e TMOD_IDLE_CHECK_OFFSET=10 -p 7777:7777 -v /etc/localtime:/etc/localtime:ro rfvgyhn/tmodloader
+
+    docker run -d --name tmod \
+               -e TMOD_SHUTDOWN_MSG="Goodbye" \
+               -e TMOD_AUTOSAVE_INTERVAL="*/15 * * * *" \
+               -e TMOD_IDLE_CHECK_INTERVAL="*/1 * * * *" \
+               -e TMOD_IDLE_CHECK_OFFSET=10 \
+               -p 7777:7777 \
+               -v /etc/localtime:/etc/localtime:ro \
+               rfvgyhn/tmodloader
 
 # Sample Docker Compose
 

--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ Name                     | Default Value  | |
 -------------------------|----------------|-
 TMOD_SHUTDOWN_MSG        | Shutting Down! | Message that appears when server is shutting down
 TMOD_AUTOSAVE_INTERVAL   | */10 * * * *   | Cron expression that specifies how often to save the world. Default is every 10 minutes.
-TMOD_IDLE_CHECK_INTERVAL | Disabled       | Cron expression that specifies how often to check if no players are online. If none are online, the server will save the world and exit. This can be useful if your server costs are based on CPU usage.
-TMOD_IDLE_CHECK_OFFSET   | 0              | This allows for sub-second resolution if the idle check interval is specified
+TMOD_IDLE_CHECK_INTERVAL | Disabled       | Cron expression that specifies how often to check if no players are online. If none are online, the server will save the world and exit. This can be useful if your server costs are based on CPU usage. Pairs well with [game-manager].
+TMOD_IDLE_CHECK_OFFSET   | 0              | This allows for sub-minute resolution if the idle check interval is specified
 
     docker run -d --name tmod \
                -e TMOD_SHUTDOWN_MSG="Goodbye" \
@@ -82,4 +82,5 @@ TMOD_IDLE_CHECK_OFFSET   | 0              | This allows for sub-second resolutio
 [default]: https://github.com/Rfvgyhn/tmodloader-docker/blob/master/config.txt
 [directly]: https://github.com/tModLoader/tModLoader/wiki/Mod-Browser#direct-download
 [Environment Variables]: #environment-variables
+[game-manager]: https://hub.docker.com/r/rfvgyhn/game-manager/
 [0]: https://hub.docker.com/r/rfvgyhn/tmodloader

--- a/README.md
+++ b/README.md
@@ -10,7 +10,17 @@ Terraria server 1.3.5.3 with tModLoader v0.11.5
 
     docker run -it --name terraria -p 7777:7777 -v /path/to/.../terraria:/terraria j123ss/tmodloader
 
+# Config File
+
+You can mount a config file in order to prevent the server requiring input on startup. See [wiki][0] for file format details.
+
+    docker run -it --name terraria -p 7777:7777 -v /path/to/.../terraria:/terraria -v /path/to/.../config.txt:/terraria-server/config.txt j123ss/tmodloader
+
 # More info
 
-How to run and manipulate [a vanilla terraria container](https://store.docker.com/community/images/ryshe/terraria). Most of these apply here.
-Original walkthrough [on reddit by GhostInThePrompt](https://www.reddit.com/r/Terraria/comments/7dbkfe/how_to_create_a_tmodloadermodded_server_on_linux).
+How to run and manipulate [a vanilla terraria container][1]. Most of these apply here.
+Original walkthrough [on reddit by GhostInThePrompt][2].
+
+[0]: https://terraria.gamepedia.com/Guide:Setting_up_a_Terraria_server#Making_a_configuration_file
+[1]: https://store.docker.com/community/images/ryshe/terraria
+[2]: https://www.reddit.com/r/Terraria/comments/7dbkfe/how_to_create_a_tmodloadermodded_server_on_linux

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ TMOD_AUTOSAVE_INTERVAL | */10 * * * *   | Cron expression that specifies how oft
                 - TMOD_SHUTDOWN_MSG="See ya!"
 
 [tModLoader]: https://www.tmodloader.net/
-[wiki]: https://terraria.gamepedia.com/Guide:Setting_up_a_Terraria_server#Making_a_configuration_file
+[wiki]: https://terraria.gamepedia.com/Server#Server_config_file
 [commands]: https://terraria.gamepedia.com/Server#List_of_console_commands
 [tMod Version]: https://img.shields.io/badge/tMod-0.11.6.2-blue
 [Terraria Version]: https://img.shields.io/badge/Terraria-1.3.5.3-blue

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [tModLoader] dedicated server  
 
-Terraria server 1.3.5.3 with tModLoader v0.11.5.
+Terraria server 1.3.5.3 with tModLoader v0.11.6.2.
 
 Supports graceful shutdown (saves when the container receives a stop command) and also supports autosaving every 10 minutes (configurable, see [Environment Variables] below).
 
@@ -66,7 +66,7 @@ TMOD_AUTOSAVE_INTERVAL | */10 * * * *   | Cron expression that specifies how oft
 [tModLoader]: https://www.tmodloader.net/
 [wiki]: https://terraria.gamepedia.com/Guide:Setting_up_a_Terraria_server#Making_a_configuration_file
 [commands]: https://terraria.gamepedia.com/Server#List_of_console_commands
-[tMod Version]: https://img.shields.io/badge/tMod-0.11.6.1-blue
+[tMod Version]: https://img.shields.io/badge/tMod-0.11.6.2-blue
 [Terraria Version]: https://img.shields.io/badge/Terraria-1.3.5.3-blue
 [Docker Stars]: https://img.shields.io/docker/stars/rfvgyhn/tmodloader.svg
 [Docker Pulls]: https://img.shields.io/docker/pulls/rfvgyhn/tmodloader.svg

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ TMOD_AUTOSAVE_INTERVAL | */10 * * * *   | Cron expression that specifies how oft
 [tModLoader]: https://www.tmodloader.net/
 [wiki]: https://terraria.gamepedia.com/Guide:Setting_up_a_Terraria_server#Making_a_configuration_file
 [commands]: https://terraria.gamepedia.com/Server#List_of_console_commands
-[tMod Version]: https://img.shields.io/badge/tMod-0.11.5-blue
+[tMod Version]: https://img.shields.io/badge/tMod-0.11.6.1-blue
 [Terraria Version]: https://img.shields.io/badge/Terraria-1.3.5.3-blue
 [Docker Stars]: https://img.shields.io/docker/stars/rfvgyhn/tmodloader.svg
 [Docker Pulls]: https://img.shields.io/docker/pulls/rfvgyhn/tmodloader.svg

--- a/README.md
+++ b/README.md
@@ -40,12 +40,13 @@ You can inject [commands] from the host machine though. For example, assuming yo
 
 # Environment Variables
 
-Name                   | Default Value  | |
------------------------|----------------|-
-TMOD_SHUTDOWN_MSG      | Shutting Down! | Message that appears when server is shutting down
-TMOD_AUTOSAVE_INTERVAL | */10 * * * *   | Cron expression that specifies how often to save the world. Default is every 10 minutes.
-
-    docker run -d --name tmod -e TMOD_SHUTDOWN_MSG="Goodbye" -e TMOD_AUTOSAVE_INTERVAL="*/15 * * * *" -p 7777:7777 -v /etc/localtime:/etc/localtime:ro rfvgyhn/tmodloader
+Name                     | Default Value  | |
+-------------------------|----------------|-
+TMOD_SHUTDOWN_MSG        | Shutting Down! | Message that appears when server is shutting down
+TMOD_AUTOSAVE_INTERVAL   | */10 * * * *   | Cron expression that specifies how often to save the world. Default is every 10 minutes.
+TMOD_IDLE_CHECK_INTERVAL | Disabled       | Cron expression that specifies how often to check if no players are online. If none are online, the server will save the world and exit. This can be useful if your server costs are based on CPU usage.
+TMOD_IDLE_CHECK_OFFSET   | 0              | This allows for sub-second resolution if the idle check interval is specified
+    docker run -d --name tmod -e TMOD_SHUTDOWN_MSG="Goodbye" -e TMOD_AUTOSAVE_INTERVAL="*/15 * * * *" -e TMOD_IDLE_CHECK_INTERVAL="*/1 * * * *" -e TMOD_IDLE_CHECK_OFFSET=10 -p 7777:7777 -v /etc/localtime:/etc/localtime:ro rfvgyhn/tmodloader
 
 # Sample Docker Compose
 

--- a/config.txt
+++ b/config.txt
@@ -1,16 +1,16 @@
 # See wiki for details
 # https://terraria.gamepedia.com/Guide:Setting_up_a_Terraria_server#Making_a_configuration_file
 
-#maxplayers=8
-#world=/terraria/ModLoader/Worlds/world1.wld
-#port=7777
+maxplayers=8
+worldname=World
+world=/terraria/ModLoader/Worlds/World.wld
+port=7777
 #password=
-#motd=Please don’t cut the purple trees!
-#worldpath=/terraria/ModLoader/Worlds
-#autocreate=3
-#difficulty=0
-#worldname=World
+motd=Please don’t cut the purple trees!
+worldpath=/terraria/ModLoader/Worlds
+autocreate=1
+difficulty=0
 #banlist=banlist.txt
-#secure=1
+secure=1
 #priority=0
 #language=en/US

--- a/config.txt
+++ b/config.txt
@@ -1,0 +1,16 @@
+# See wiki for details
+# https://terraria.gamepedia.com/Guide:Setting_up_a_Terraria_server#Making_a_configuration_file
+
+#maxplayers=8
+#world=/terraria/ModLoader/Worlds/world1.wld
+#port=7777
+#password=
+#motd=Please don’t cut the purple trees!
+#worldpath=/terraria/ModLoader/Worlds
+#autocreate=3
+#difficulty=0
+#worldname=World
+#banlist=banlist.txt
+#secure=1
+#priority=0
+#language=en/US

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,11 +1,11 @@
 #!/bin/sh
 
 pipe=/tmp/tmod.out
+players=/tmp/tmod.players.out
 
 function shutdown() {
   [ -n "$TMOD_SHUTDOWN_MSG" ] && inject "say $TMOD_SHUTDOWN_MSG"
   inject "exit"
-  
   tmuxPid=$(pgrep tmux)
   tmodPid=$(pgrep --parent $tmuxPid Main)
   while [ -e /proc/$tmodPid ]; do
@@ -22,13 +22,17 @@ else
   trap shutdown SIGTERM SIGINT
 
   saveMsg='Autosave - $(date +"%Y-%m-%d %T")'
+  idleMsg='Idle Check - $(date +"%Y-%m-%d %T")'
   
-  if ! crontab -l | grep -q "Autosave"; then
+  if [ ! -z "$TMOD_AUTOSAVE_INTERVAL" ] && ! crontab -l | grep -q "Autosave"; then
     (crontab -l 2>/dev/null; echo "$TMOD_AUTOSAVE_INTERVAL echo \"$saveMsg\" > $pipe && inject save") | crontab -
   fi
+  if [ ! -z "$TMOD_IDLE_CHECK_INTERVAL" ] && ! crontab -l | grep -q "Idle Check"; then
+    (crontab -l 2>/dev/null; echo "$TMOD_IDLE_CHECK_INTERVAL echo \"$idleMsg\" > $pipe && handle-idle $players") | crontab -
+  fi
   mkfifo $pipe
-  tmux new-session -d "$server -config config.txt > $pipe" &
-  /usr/sbin/crond -d 8
+  tmux new-session -d "$server -config config.txt | tee $pipe $players" &
+  sleep 60 && /usr/sbin/crond -d 8 &
   cat $pipe &
 
   wait ${!}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -22,7 +22,10 @@ else
   trap shutdown SIGTERM SIGINT
 
   saveMsg='Autosave - $(date +"%Y-%m-%d %T")'
-  (crontab -l 2>/dev/null; echo "$TMOD_AUTOSAVE_INTERVAL echo \"$saveMsg\" > $pipe && inject save") | crontab -
+  
+  if ! crontab -l | grep -q "Autosave"; then
+    (crontab -l 2>/dev/null; echo "$TMOD_AUTOSAVE_INTERVAL echo \"$saveMsg\" > $pipe && inject save") | crontab -
+  fi
   mkfifo $pipe
   tmux new-session -d "$server -config config.txt > $pipe" &
   /usr/sbin/crond -d 8

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+
+pipe=/tmp/tmod.out
+
+function shutdown() {
+  [ -n "$TMOD_SHUTDOWN_MSG" ] && inject "say $TMOD_SHUTDOWN_MSG"
+  inject "exit"
+  
+  tmuxPid=$(pgrep tmux)
+  tmodPid=$(pgrep --parent $tmuxPid Main)
+  while [ -e /proc/$tmodPid ]; do
+    sleep .5
+  done
+  rm $pipe
+}
+
+server="/terraria-server/tModLoaderServer.bin.x86_64"
+
+if [ "$1" = "setup" ]; then
+  $server
+else
+  trap shutdown SIGTERM SIGINT
+
+  saveMsg='Autosave - $(date +"%Y-%m-%d %T")'
+  (crontab -l 2>/dev/null; echo "$TMOD_AUTOSAVE_INTERVAL echo \"$saveMsg\" > $pipe && inject save") | crontab -
+  mkfifo $pipe
+  tmux new-session -d "$server -config config.txt > $pipe" &
+  /usr/sbin/crond -d 8
+  cat $pipe &
+
+  wait ${!}
+fi

--- a/handle-idle.sh
+++ b/handle-idle.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+players="$1"
+
+sleep $TMOD_IDLE_CHECK_OFFSET
+
+echo "" > "$players"
+inject playing && sleep .2
+if ! grep -q "[1-9]" "$players"; then
+    inject "exit"
+fi

--- a/inject.sh
+++ b/inject.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+tmux send-keys "$1" Enter

--- a/inject.sh
+++ b/inject.sh
@@ -1,3 +1,6 @@
 #!/bin/sh
 
+# If no worlds exist, don't bother sending any commands
+ls /terraria/ModLoader/Worlds/*.wld >/dev/null || exit
+
 tmux send-keys "$1" Enter


### PR DESCRIPTION
* Tmodloader release for linux changed to .tar.gz so needed to use tar to decompress it
* Moved versions to args so it's easier to update
* chmod TerrariaServer.* so no need for sed
* Use `ENTRYPOINT` to allow passing command line parameters
* Add support for mounting a config file so you don't have to manually choose the options on container startup